### PR TITLE
Add max page range selector

### DIFF
--- a/pdf/pdf.go
+++ b/pdf/pdf.go
@@ -56,6 +56,17 @@ func NormalizePageRange(pageCount int, pageRange string) (*string, *int, error) 
 				}
 
 				pageNumbers = append(pageNumbers, pageCount-parsedPageNumber)
+			} else if strings.HasPrefix(pageRangeParts[pageRangePartI], "m") {
+				parsedPageNumber, err := strconv.Atoi(strings.TrimPrefix(pageRangeParts[pageRangePartI], "m"))
+				if err != nil || parsedPageNumber < 1 {
+					return nil, nil, fmt.Errorf("%s is not a valid page number", strings.TrimPrefix(pageRangeParts[pageRangePartI], "m"))
+				}
+
+				if parsedPageNumber > pageCount {
+					pageNumbers = append(pageNumbers, pageCount)
+				} else {
+					pageNumbers = append(pageNumbers, parsedPageNumber)
+				}
 			} else {
 				parsedPageNumber, err := strconv.Atoi(pageRangeParts[pageRangePartI])
 				if err != nil {

--- a/pdf/pdf_test.go
+++ b/pdf/pdf_test.go
@@ -61,6 +61,13 @@ func TestNormalizePageRange(t *testing.T) {
 			"1,2,3,4,5",
 			"",
 		},
+		{
+			"test maximum page-range",
+			5,
+			"1-m10",
+			"1,2,3,4,5",
+			"",
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
You might want to render the first 10 pages, regardless of how many pages the PDF actual has. Currently, this throws an error:
`pdfion-cli render --pages '1-10'`
`10 is not a valid page number, the document has 5 page(s)`

Similar to the `r` prefix, this adds a `m` prefix in page ranges to select a maximum page range:
`pdfion-cli render --pages '1-m10'`